### PR TITLE
Override SSLSocketFactory#createSocket() to avoid unconnected sockets exception

### DIFF
--- a/src/main/java/org/ferris/catalina/jndi/net/ssl/SSLSocketFactory.java
+++ b/src/main/java/org/ferris/catalina/jndi/net/ssl/SSLSocketFactory.java
@@ -46,6 +46,15 @@ public class SSLSocketFactory extends javax.net.ssl.SSLSocketFactory {
         }
     }
 
+    /**
+     * (non-Javadoc)
+     * @see javax.net.SocketFactory#createSocket()
+     */
+    @Override
+    public Socket createSocket() throws IOException {
+        return trustAllSSLSocketFactory.createSocket();
+    }
+
     /*
      * (non-Javadoc)
      * @see javax.net.SocketFactory#createSocket(java.net.InetAddress, int)

--- a/src/main/java/org/ferris/catalina/jndi/realm/JNDIRealm.java
+++ b/src/main/java/org/ferris/catalina/jndi/realm/JNDIRealm.java
@@ -58,14 +58,6 @@ public class JNDIRealm extends org.apache.catalina.realm.JNDIRealm {
         Hashtable<String, String> env = super.getDirectoryContextEnvironment();
         env.put("java.naming.ldap.factory.socket", "org.ferris.catalina.jndi.net.ssl.SSLSocketFactory");
 
-        // Remove this property!
-        //
-        // If it's here it causes the following exception:
-        //
-        // javax.naming.CommunicationException: localhost:389 [Root exception is java.net.SocketException: Unconnected
-        // sockets not implemented]
-        env.remove("com.sun.jndi.ldap.connect.timeout");
-
         return env;
     }
 }

--- a/src/test/java/org/ferris/catalina/jndi/realm/JNDIRealmTest.java
+++ b/src/test/java/org/ferris/catalina/jndi/realm/JNDIRealmTest.java
@@ -21,7 +21,6 @@ public class JNDIRealmTest {
         realm.setConnectionTimeout("5000");
 
         Hashtable<String, String> env = realm.getDirectoryContextEnvironment();
-        assertFalse(env.containsKey("com.sun.jndi.ldap.connect.timeout"));
         assertEquals(SSLSocketFactory.class.getName(), env.get("java.naming.ldap.factory.socket"));
     }
 }


### PR DESCRIPTION
This PR implements a fix to overcome the `javax.naming.CommunicationException: localhost:389 [Root exception is java.net.SocketException: Unconnected sockets not implemented]` exception when a custom `SSLSocketFactory` is used in `JNDIRealm`.

### Root Cause
All `createSocket()` methods having arguments are declared abstract in `SSLSocketFactory`, but not the `createSocket()` method without any arguments.
So, when `SSLSocketFactory` is subclassed, unless `createSocket()` (without arguments) is overridden as well, this exception is thrown when this is invoked.

### Changes
* `createSocket()` is overridden explicitly in `SSLSocketFactory`
* Cleaned-up code which was removing `com.sun.jndi.ldap.connect.timeout` property from the custom `JNDIRealm`
* Removed assertion from unit test that is no longer valid